### PR TITLE
fix a compile warning

### DIFF
--- a/base/int128.cpp
+++ b/base/int128.cpp
@@ -2,7 +2,9 @@
 // All Rights Reserved.
 //
 
+#ifndef __STDC_CONSTANT_MACROS
 #define __STDC_CONSTANT_MACROS
+#endif
 
 #include "toft/base/int128.h"
 


### PR DESCRIPTION
The macro __STDC_CONSTANT_MACROS is predefined in my toolchain and this change fixes a warning like this:

```
toft/base/int128.cpp:5:0: warning: "__STDC_CONSTANT_MACROS" redefined [enabled by default]
```
