### PR TITLE
fix for mime test

### DIFF
--- a/net/mime/mime_test.cpp
+++ b/net/mime/mime_test.cpp
@@ -11,7 +11,7 @@ namespace toft {
 TEST(MimeType, FromFileExtension)
 {
     MimeType mt;
-    ASSERT_TRUE(mt.FromFileExtension("txt"));
+    ASSERT_TRUE(mt.FromFileExtension(".txt"));
     EXPECT_EQ("text/plain", mt.ToString());
     ASSERT_FALSE(mt.FromFileExtension("###"));
 }


### PR DESCRIPTION
```MimeType::FromFileExtension(const String& file_name)```
the `file_name` string should begin with a dot, like '.txt' instead of 'txt'.